### PR TITLE
Added DELETE Endpoint for HelpRequest table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -37,6 +37,7 @@ public class HelpRequestController extends ApiController {
     HelpRequestRepository helpRequestRepository;
 
     @Operation(summary= "List of help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<HelpRequest> allHelpRequest() {
         Iterable<HelpRequest> request = helpRequestRepository.findAll();
@@ -44,6 +45,7 @@ public class HelpRequestController extends ApiController {
     }
 
     @Operation(summary= "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
     public HelpRequest postHelpRequest(
             @Parameter(name="requestEmail") @RequestParam String requestEmail,

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
@@ -73,6 +74,17 @@ public class HelpRequestController extends ApiController {
         HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
 
         return savedHelpRequest;
+    }
+
+    @Operation(summary= "Get a single help request")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
     }
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,79 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "HelpRequest")
+@RequestMapping("/api/helprequest")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @Operation(summary= "List of help requests")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequest() {
+        Iterable<HelpRequest> request = helpRequestRepository.findAll();
+        return request;
+    }
+
+    @Operation(summary= "Create a new help request")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requestEmail") @RequestParam String requestEmail,
+            @Parameter(name="teamID") @RequestParam String teamID,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="requestTime", description="in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="solved") @RequestParam boolean solved)
+
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requesttime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequestEmail(requestEmail);
+        helpRequest.setTeamId(teamID);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+
+}
+
+
+

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -87,6 +87,28 @@ public class HelpRequestController extends ApiController {
         return helpRequest;
     }
 
+    @Operation(summary= "Update a single help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public HelpRequest updateHelpRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid HelpRequest incoming) {
+
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequest.setRequestEmail(incoming.getRequestEmail());
+        helpRequest.setTeamId(incoming.getTeamId());
+        helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+        helpRequest.setRequestTime(incoming.getRequestTime());
+        helpRequest.setExplanation(incoming.getExplanation());
+        helpRequest.setSolved(incoming.getSolved());
+
+        helpRequestRepository.save(helpRequest);
+
+        return helpRequest;
+    }
+
 }
 
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -109,6 +109,18 @@ public class HelpRequestController extends ApiController {
         return helpRequest;
     }
 
+    @Operation(summary= "Delete a help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
+
 }
 
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
 import java.util.ArrayList;
@@ -146,5 +147,64 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                      String responseString = response.getResponse().getContentAsString();
                      assertEquals(expectedJson, responseString);
              }
+             
+
+        // Tests for GET /api/ucsbdates?id=...
+
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+                LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest = HelpRequest.builder()
+                                .requestEmail("cgaucho@ucsb.edu")
+                                .teamId("f23-7pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt)
+                                .explanation("Dokku problems")
+                                .solved(true)
+                                .build();
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(helpRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
 
     }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -4,7 +4,6 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.HelpRequest;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 
 import java.util.ArrayList;
@@ -292,5 +291,60 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                  assertEquals("HelpRequest with id 67 not found", json.get("message"));
  
          }
+
+
+          // Tests for DELETE /api/ucsbdates?id=... 
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_help_request() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requestEmail("cgaucho@ucsb.edu")
+                                .teamId("f23-7pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt1)
+                                .explanation("Dokku problems")
+                                .solved(true)
+                                .build();
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helpRequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                verify(helpRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+        }
+        
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequest?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 not found", json.get("message"));
+        }
 
     }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -118,7 +118,7 @@ public class HelpRequestControllerTests extends ControllerTestCase {
      
              @WithMockUser(roles = { "ADMIN", "USER" })
              @Test
-             public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+             public void an_admin_user_can_post_a_new_helprequest() throws Exception {
                      // arrange
      
                      LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
@@ -129,15 +129,14 @@ public class HelpRequestControllerTests extends ControllerTestCase {
                                 .tableOrBreakoutRoom("11")
                                 .requestTime(ldt1)
                                 .explanation("Dokku problems")
-                                .solved(false)
+                                .solved(true)
                                 .build();
      
                      when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
      
-                     ///api/helprequest/post?requestEmail=cgaucho%40ucsb.edu&teamID=f23-7pm-3&tableOrBreakoutRoom=11&requestTime=2023-10-30T17%3A35&explanation=Dokku%20problems&solved=false
                      // act
                      MvcResult response = mockMvc.perform(
-                                     post("/api/helprequest/post?requestEmail=cgaucho%40ucsb.edu&teamID=f23-7pm-3&tableOrBreakoutRoom=11&requestTime=2023-10-30T17%3A35&explanation=Dokku%20problems&solved=false")
+                                     post("/api/helprequest/post?requestEmail=cgaucho@ucsb.edu&teamID=f23-7pm-3&tableOrBreakoutRoom=11&requestTime=2022-01-03T00:00:00&explanation=Dokku problems&solved=true")
                                                      .with(csrf()))
                                      .andExpect(status().isOk()).andReturn();
      

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,151 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+       @MockBean
+        HelpRequestRepository helpRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Tests for GET /api/ucsbdates/all
+        
+      @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requestEmail("cgaucho@ucsb.edu")
+                                .teamId("f23-7pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt1)
+                                .explanation("Dokku problems")
+                                .solved(false)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+                HelpRequest helpRequest2 = HelpRequest.builder()
+                                .requestEmail("cgaucho@ucsb.edu")
+                                .teamId("f23-7pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt2)
+                                .explanation("Dokku problems")
+                                .solved(false)
+                                .build();
+
+                ArrayList<HelpRequest> expectedHelpRequest = new ArrayList<>();
+                expectedHelpRequest.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+                when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequest);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequest/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedHelpRequest);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+        
+             // Tests for POST /api/ucsbdates/post...
+
+             @Test
+             public void logged_out_users_cannot_post() throws Exception {
+                     mockMvc.perform(post("/api/helprequest/post"))
+                                     .andExpect(status().is(403));
+             }
+     
+             @WithMockUser(roles = { "USER" })
+             @Test
+             public void logged_in_regular_users_cannot_post() throws Exception {
+                     mockMvc.perform(post("/api/helprequest/post"))
+                                     .andExpect(status().is(403)); // only admins can post
+             }
+     
+             @WithMockUser(roles = { "ADMIN", "USER" })
+             @Test
+             public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+                     // arrange
+     
+                     LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+     
+                     HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requestEmail("cgaucho@ucsb.edu")
+                                .teamId("f23-7pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt1)
+                                .explanation("Dokku problems")
+                                .solved(false)
+                                .build();
+     
+                     when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+     
+                     ///api/helprequest/post?requestEmail=cgaucho%40ucsb.edu&teamID=f23-7pm-3&tableOrBreakoutRoom=11&requestTime=2023-10-30T17%3A35&explanation=Dokku%20problems&solved=false
+                     // act
+                     MvcResult response = mockMvc.perform(
+                                     post("/api/helprequest/post?requestEmail=cgaucho%40ucsb.edu&teamID=f23-7pm-3&tableOrBreakoutRoom=11&requestTime=2023-10-30T17%3A35&explanation=Dokku%20problems&solved=false")
+                                                     .with(csrf()))
+                                     .andExpect(status().isOk()).andReturn();
+     
+                     // assert
+                     verify(helpRequestRepository, times(1)).save(helpRequest1);
+                     String expectedJson = mapper.writeValueAsString(helpRequest1);
+                     String responseString = response.getResponse().getContentAsString();
+                     assertEquals(expectedJson, responseString);
+             }
+
+    }


### PR DESCRIPTION
In this pr, I added the code for the DELETE endpoint; the program passed the mvn test successfully, as well as the jacoco test and pitest test.

A link to the dokku can be found here: https://team02-ivan512az-dev.dokku-11.cs.ucsb.edu/

Closes #36 